### PR TITLE
Add config parameter to configure SSL varification.

### DIFF
--- a/flik/client/baseService.py
+++ b/flik/client/baseService.py
@@ -2,22 +2,21 @@ import getpass, keyring
 from functools import wraps
 from zeep import CachingClient as Client
 from zeep.exceptions import Fault
-from ..common import config, storage
+from ..common import config, storage, util
 from ..common.util import sessionID
 from zeep.transports import Transport
 
 
 def client():
-    transport = Transport()
-    transport.session.verify = False
-    return Client(config.load()['url'] + 'BaseService.wsdl', transport=transport)
+    transport = util.create_https_transport()
+    return Client(config.load()['url'] + '/BaseService.wsdl', transport=transport)
 
 
 def login():
     username = (config.load() or config.reconfigure())['username']
     password = keyring.get_password('flik', username) or getpass.getpass()
 
-    session = client().create_service('{http://blueant.axis.proventis.net/}BaseBinding', address='https://demosystem.blueant.cloud/services/BaseService').Login(username, password)
+    session = client().create_service('{http://blueant.axis.proventis.net/}BaseBinding', address=config.load()['url']+'/services/BaseService').Login(username, password)
     storage.writeShare('sessionID', session.sessionID)
     keyring.set_password('flik', username, password)
 

--- a/flik/client/humanService.py
+++ b/flik/client/humanService.py
@@ -1,6 +1,7 @@
 from zeep import CachingClient as Client
-from ..common import config
+from ..common import config, util
 
 
 def client():
-    return Client(config.load()['url'] + 'HumanService.wsdl')
+    transport = util.create_https_transport
+    return Client(config.load()['url'] + '/HumanService.wsdl', transport=transport)

--- a/flik/client/masterDataService.py
+++ b/flik/client/masterDataService.py
@@ -1,12 +1,13 @@
 from zeep import CachingClient as Client
 from yaml import safe_dump
-from ..common import config, storage
+from ..common import config, storage, util
 from ..common.util import quote, sessionID
 from .baseService import autologin
 
 
 def client():
-    return Client(config.load()['url'] + 'MasterDataService.wsdl').create_service('{http://blueant.axis.proventis.net/}MasterDataBinding', address='https://demosystem.blueant.cloud/services/MasterDataService')
+    transport = util.create_https_transport() 
+    return Client(config.load()['url'] + '/MasterDataService.wsdl', transport=transport).create_service('{http://blueant.axis.proventis.net/}MasterDataBinding', address=config.load()['url']+'/services/MasterDataService')
 
 
 @autologin

--- a/flik/client/projectsService.py
+++ b/flik/client/projectsService.py
@@ -1,6 +1,7 @@
 from zeep import CachingClient as Client
-from ..common import config
+from ..common import config, util
 
 
 def client():
-    return Client(config.load()['url'] + 'ProjectsService.wsdl')
+    transport = util.create_https_transport()
+    return Client(config.load()['url'] + '/ProjectsService.wsdl', transport=transport)

--- a/flik/client/workTimeAccountingService.py
+++ b/flik/client/workTimeAccountingService.py
@@ -1,6 +1,7 @@
-from zeep import CachingClient as Client
 from yaml import safe_dump, safe_load
-from ..common import config, storage, dateparam
+from zeep import CachingClient as Client
+from zeep.transports import Transport
+from ..common import config, storage, dateparam, util
 from ..common.util import quote, sessionID
 from .baseService import autologin
 
@@ -8,8 +9,9 @@ from .baseService import autologin
 def client():
     global service
     if not 'service' in globals():
-        service =  Client(config.load()['url'] + 'WorktimeAccountingService.wsdl')
-        service = client().create_service('{http://blueant.axis.proventis.net/}WorktimeAccountingBinding', address='https://demosystem.blueant.cloud/services/WorktimeAccountingService')
+        transport = util.create_https_transport() 
+        service =  Client(config.load()['url'] + '/WorktimeAccountingService.wsdl', transport=transport)
+        service = client().create_service('{http://blueant.axis.proventis.net/}WorktimeAccountingBinding', address=config.load()['url']+'/services/WorktimeAccountingService')
     return service
 
 

--- a/flik/common/util.py
+++ b/flik/common/util.py
@@ -1,4 +1,9 @@
+import logging
+from requests import Session
+from zeep.transports import Transport
+
 from . import storage
+from . import config
 
 
 def quote(toquote):
@@ -10,3 +15,21 @@ def quote(toquote):
 
 def sessionID():
     return storage.readShare('sessionID')
+
+
+def create_https_transport():
+    """
+    Uses given config to create transport for https connections.
+    If 'verify-cert' (path to a certificate) is given within the config.yaml it will be used to varify the connection.
+    """
+    session = Session()
+
+    try:
+        session.verify = config.load()['verify-cert']
+        # disable warnings
+        import urllib3
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    except KeyError:
+        logging.debug("No 'verify-cert' key found in config. Using build in CA chain.")
+
+    return Transport(session=session)  


### PR DESCRIPTION
### Functionality changes:
This adds a new config parameter `verify-cert` to the `config.yaml`:
```
// config.yaml
url: https://<URL>     
username: <UserName>      
verify-cert: <PathToCA-BundleCert || False>        
```
It allows to configure how and if the ssl certificate is verified.

Options:
- Use a path to a cert as shown in [here](https://docs.python-zeep.org/en/master/transport.html)
- Or disable verification completely. **NOT RECOMMENDED** by setting it to 'False' 

### Code changes:
- Add config parameter.
- Add utility function to create corresponding ssl transport config. (Maybe implemented in the wrong place)
- Consistently use the `url` from config not the test instance one.

regards
